### PR TITLE
Use impl traits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: rust
 rust:
-- 1.1.0
-- 1.2.0
-- beta
 - nightly
 os:
 - linux

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! Procure is a library for grabbing various types of metrics from a
 //! Linux system.
 
+#![feature(conservative_impl_trait)]
+
 // Externs
 extern crate sysconf;
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -3,20 +3,8 @@
 use std::fs;
 use std::iter::Iterator;
 
-pub struct Pids {
-    iter: Box<Iterator<Item=i32>>,
-}
-
-impl Iterator for Pids {
-    type Item = i32;
-
-    fn next(&mut self) -> Option<i32> {
-        self.iter.next()
-    }
-}
-
-fn pids_from_path(proc_path: &str) -> Pids {
-    let iter = fs::read_dir(proc_path).unwrap()
+fn pids_from_path(proc_path: &str) -> impl Iterator<Item=i32> {
+    fs::read_dir(proc_path).unwrap()
         // Process directories might have gone away since
         // the directory was read. It's fine to ignore those.
         .filter_map(|entry| entry.ok())
@@ -24,11 +12,10 @@ fn pids_from_path(proc_path: &str) -> Pids {
         // parse as unicode.
         .filter_map(|entry| entry.file_name().into_string().ok())
         // Remove any entries that can't be converted to an integer.
-        .filter_map(|entry| entry.parse::<i32>().ok());
-    Pids{iter: Box::new(iter)}
+        .filter_map(|entry| entry.parse::<i32>().ok())
 }
 
-pub fn pids() -> Pids {
+pub fn pids() -> impl Iterator<Item=i32> {
     pids_from_path("/proc")
 }
 


### PR DESCRIPTION
Get rid of the custom iterator that wrapped a boxed iterator. Can use impl traits now instead
Update travis to only test on nightly for now